### PR TITLE
fix: remember-me 쿠키 도메인, 이름 서버별 분리

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/config/SecurityConfig.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/config/SecurityConfig.java
@@ -32,6 +32,12 @@ public class SecurityConfig {
 	@Value("${security.secret-key}")
 	String secretKey;
 
+	@Value("${security.rememberme.cookieName}")
+	private String rememberMeCookieName;
+
+	@Value("${security.rememberme.cookieDomain:}")
+	private String rememberMeCookieDomain;
+
 	private final CorsProperties corsProperties;
 	private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
 
@@ -77,6 +83,8 @@ public class SecurityConfig {
 			.rememberMe(rememberMe ->
 				rememberMe
 					.userDetailsService(customUserDetailService)
+					.rememberMeCookieName(rememberMeCookieName)
+					.rememberMeCookieDomain(rememberMeCookieDomain)
 					.key(secretKey)
 			)
 			.addFilterBefore(corsFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -60,3 +60,6 @@ alarm:
   secret-key: ${ALARM_SECRET}
 security:
   secret-key: ${SESSION_SECRET}
+  rememberme:
+    cookieName: ${REMEMBERME_NAME}
+    cookieDomain: ${REMEMBERME_DOMAIN}

--- a/monicar-control-center/src/main/resources/application-local.yml
+++ b/monicar-control-center/src/main/resources/application-local.yml
@@ -65,3 +65,6 @@ alarm:
   secret-key: ${ALARM_SECRET}
 security:
   secret-key: ${SESSION_SECRET}
+  rememberme:
+    cookieName: ${REMEMBERME_NAME}
+    cookieDomain: ${REMEMBERME_DOMAIN}

--- a/monicar-control-center/src/main/resources/application-prod.yml
+++ b/monicar-control-center/src/main/resources/application-prod.yml
@@ -66,6 +66,9 @@ alarm:
   secret-key: ${ALARM_SECRET}
 security:
   secret-key: ${SESSION_SECRET}
+  rememberme:
+    cookieName: ${REMEMBERME_NAME}
+    cookieDomain: ${REMEMBERME_DOMAIN}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 서버별로 쿠키 도메인명 분리하도록 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#23 
<!-- ex) #이슈번호, #이슈번호 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인