### PR TITLE
fix: Redis에서 가져온 CycleInfo를 Entity로 변환하여 DB 저장 처리

### DIFF
--- a/monicar-rabbitmq-collector/src/main/java/org/rabbitmqcollector/location/application/port/CycleInfoRepository.java
+++ b/monicar-rabbitmq-collector/src/main/java/org/rabbitmqcollector/location/application/port/CycleInfoRepository.java
@@ -3,11 +3,12 @@ package org.rabbitmqcollector.location.application.port;
 import java.util.List;
 
 import org.rabbitmqcollector.location.domain.CycleInfo;
+import org.rabbitmqcollector.location.infrastructure.jpa.entity.CycleInfoEntity;
 
 public interface CycleInfoRepository {
 	CycleInfo save(CycleInfo cycleInfo);
 
 	CycleInfo findTopByVehicleIdOrderByCreatedAtDesc(Long id);
 
-	void saveAll(List<CycleInfo> cycleInfos);
+	void saveAll(List<CycleInfoEntity> cycleInfos);
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- Redis에서 가져온 CycleInfo 객체를 JPA 엔티티(CycleInfoEntity)로 변환한 후 saveAll() 하여 Hibernate 버전 충돌(ObjectOptimisticLockingFailureException) 방지
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#87
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말

-
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인